### PR TITLE
Remove bin/release

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-# bin/release <build-dir>
-
-cat << EOF
-addons: []
-default_process_types:
-  web: npm start
-EOF


### PR DESCRIPTION
`bin/release` is optional. By removing it, it will fall back to whatever other buildpacks define.