### PR TITLE
Make sure the tests support Node 6.x

### DIFF
--- a/spec/metrics_spec.rb
+++ b/spec/metrics_spec.rb
@@ -20,42 +20,46 @@ describe "Node Metrics Hello World" do
   elsif ENV['TEST_ALL_NODE_VERSIONS'] == 'true'
     versions = resolve_all_supported_node_versions()
   else 
-    versions = resolve_node_version(["8.x", "9.x", "10.x"])
+    versions = resolve_node_version(["6.x", "8.x", "9.x", "10.x"])
   end
 
   versions.each do |version|
-    context "a single-process node v#{version} app" do
-      let(:app) {
-        Hatchet::Runner.new(
-          "node-metrics-single-process",
-          buildpacks: ["heroku/nodejs", "https://github.com/heroku/heroku-nodejs-metrics-buildpack.git##{branch}"]
-        )
-      }
-      let(:node_version) { version }
-      it "should deploy" do
-        app.deploy do |app|
-          expect(app.output).to include("-----> Build succeeded!")
-          expect(app.output).to include("HerokuNodejsRuntimeMetrics app detected")
-          expect(successful_body(app).strip).to eq("--require /app/.heroku/heroku-nodejs-plugin")
+    if version_supports_metrics(version)
+      context "a single-process node v#{version} app" do
+        let(:app) {
+          Hatchet::Runner.new(
+            "node-metrics-single-process",
+            buildpacks: ["heroku/nodejs", "https://github.com/heroku/heroku-nodejs-metrics-buildpack.git##{branch}"]
+          )
+        }
+        let(:node_version) { version }
+        it "should deploy" do
+          app.deploy do |app|
+            expect(app.output).to include("-----> Build succeeded!")
+            expect(app.output).to include("HerokuNodejsRuntimeMetrics app detected")
+            expect(successful_body(app).strip).to eq("--require /app/.heroku/heroku-nodejs-plugin")
+          end
         end
       end
     end
   end
 
   versions.each do |version|
-    context "a multi-process node v#{version} app" do
-      let(:app) {
-        Hatchet::Runner.new(
-          "node-metrics-multi-process",
-          buildpacks: ["heroku/nodejs", "https://github.com/heroku/heroku-nodejs-metrics-buildpack.git##{branch}"]
-        )
-      }
-      let(:node_version) { version }
-      it "should deploy" do
-        app.deploy do |app|
-          expect(app.output).to include("-----> Build succeeded!")
-          expect(app.output).to include("HerokuNodejsRuntimeMetrics app detected")
-          expect(successful_body(app).strip).to eq("Hello, world!")
+    if version_supports_metrics(version)
+      context "a multi-process node v#{version} app" do
+        let(:app) {
+          Hatchet::Runner.new(
+            "node-metrics-multi-process",
+            buildpacks: ["heroku/nodejs", "https://github.com/heroku/heroku-nodejs-metrics-buildpack.git##{branch}"]
+          )
+        }
+        let(:node_version) { version }
+        it "should deploy" do
+          app.deploy do |app|
+            expect(app.output).to include("-----> Build succeeded!")
+            expect(app.output).to include("HerokuNodejsRuntimeMetrics app detected")
+            expect(successful_body(app).strip).to eq("Hello, world!")
+          end
         end
       end
     end
@@ -83,25 +87,27 @@ describe "Node Metrics" do
   end
 
   versions.each do |version|
-    context "a multi-process node v#{version} app" do
+    if version_supports_metrics(version)
+      context "a multi-process node v#{version} app" do
 
-      let(:app) {
-        Hatchet::Runner.new(
-          "node-metrics-test-app",
-          buildpacks: ["heroku/nodejs", "https://github.com/heroku/heroku-nodejs-metrics-buildpack.git##{branch}"]
-        )
-      }
+        let(:app) {
+          Hatchet::Runner.new(
+            "node-metrics-test-app",
+            buildpacks: ["heroku/nodejs", "https://github.com/heroku/heroku-nodejs-metrics-buildpack.git##{branch}"]
+          )
+        }
 
-      let(:node_version) { version }
-      it "should deploy" do
-        app.deploy do |app|
-          expect(app.output).to include("-----> Build succeeded!")
-          expect(app.output).to include("HerokuNodejsRuntimeMetrics app detected")
-          data = successful_json_body(app)
-          expect(data["gauges"]["node.eventloop.delay.ms.max"]).to be >= 2000
-          expect(data["counters"]["node.gc.collections"]).to be >= 0
-          expect(data["counters"]["node.gc.young.collections"]).to be >= 0
-          expect(data["counters"]["node.gc.old.collections"]).to be >= 0
+        let(:node_version) { version }
+        it "should deploy" do
+          app.deploy do |app|
+            expect(app.output).to include("-----> Build succeeded!")
+            expect(app.output).to include("HerokuNodejsRuntimeMetrics app detected")
+            data = successful_json_body(app)
+            expect(data["gauges"]["node.eventloop.delay.ms.max"]).to be >= 2000
+            expect(data["counters"]["node.gc.collections"]).to be >= 0
+            expect(data["counters"]["node.gc.young.collections"]).to be >= 0
+            expect(data["counters"]["node.gc.old.collections"]).to be >= 0
+          end
         end
       end
     end

--- a/spec/metrics_spec.rb
+++ b/spec/metrics_spec.rb
@@ -83,7 +83,7 @@ describe "Node Metrics" do
   elsif ENV['TEST_ALL_NODE_VERSIONS'] == 'true'
     versions = resolve_all_supported_node_versions()
   else 
-    versions = resolve_node_version(["8.x", "9.x", "10.x"])
+    versions = resolve_node_version(["6.x", "8.x", "9.x", "10.x"])
   end
 
   versions.each do |version|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -60,6 +60,10 @@ def resolve_all_supported_node_versions(options = {})
   list = JSON.parse(body).map { |n| n['number'] }
 
   list.select do |n| 
-    SemVersion.new(n).satisfies?('>= 8.0.0')
+    SemVersion.new(n).satisfies?('>= 6.0.0')
   end
+end
+
+def version_supports_metrics(version)
+  SemVersion.new(version).satisfies?('>= 8.0.0')
 end


### PR DESCRIPTION
`nodebin` now runs these tests whenever a new version of Node is released. When I wrote them I did not think about running them for Node 6, which is still being released with security updates.

This skips all of the metrics tests for Node versions less than `8.0.0`